### PR TITLE
Add WeatherDress iOS app skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# WeatherDress
+
+A minimalistic iOS app that shows current weather and suggests how to dress. Includes a widget for quick glance advice.
+
+## Features
+- Fetches weather from the open-meteo API
+- Simple SwiftUI interface
+- WidgetKit extension
+
+## Building
+Open `WeatherDressApp` in Xcode and build/run.

--- a/WeatherDressApp/ContentView.swift
+++ b/WeatherDressApp/ContentView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var viewModel = WeatherViewModel()
+
+    var body: some View {
+        VStack(spacing: 16) {
+            if let weather = viewModel.weather {
+                Text("\(Int(weather.temperature))°")
+                    .font(.system(size: 64, weight: .thin))
+                Text(weather.condition)
+                    .font(.headline)
+                Text(viewModel.advice(for: weather))
+                    .font(.subheadline)
+                    .padding(.top)
+            } else {
+                ProgressView()
+            }
+        }
+        .task {
+            await viewModel.load()
+        }
+        .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/WeatherDressApp/WeatherDressApp.swift
+++ b/WeatherDressApp/WeatherDressApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct WeatherDressApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/WeatherDressApp/WeatherDressWidget/WeatherDressWidget.swift
+++ b/WeatherDressApp/WeatherDressWidget/WeatherDressWidget.swift
@@ -1,0 +1,55 @@
+import WidgetKit
+import SwiftUI
+
+struct WeatherDressEntry: TimelineEntry {
+    let date: Date
+    let weather: Weather
+    let advice: String
+}
+
+struct WeatherProvider: TimelineProvider {
+    let service = WeatherService()
+    func placeholder(in context: Context) -> WeatherDressEntry {
+        WeatherDressEntry(date: Date(), weather: Weather(temperature: 20, condition: "Clear", rainProbability: 0), advice: "Short sleeves are fine.")
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (WeatherDressEntry) -> Void) {
+        completion(placeholder(in: context))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<WeatherDressEntry>) -> Void) {
+        Task {
+            let weather = try? await service.fetchWeather()
+            let entry = WeatherDressEntry(date: Date(), weather: weather ?? placeholder(in: context).weather, advice: WeatherViewModel().advice(for: weather ?? placeholder(in: context).weather))
+            completion(Timeline(entries: [entry], policy: .after(Date().addingTimeInterval(60*60))))
+        }
+    }
+}
+
+struct WeatherDressWidgetEntryView : View {
+    var entry: WeatherProvider.Entry
+
+    var body: some View {
+        VStack {
+            Text("\(Int(entry.weather.temperature))°")
+                .font(.title)
+            Text(entry.advice)
+                .font(.caption)
+        }
+        .padding()
+    }
+}
+
+@main
+struct WeatherDressWidget: Widget {
+    let kind: String = "WeatherDressWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: WeatherProvider()) { entry in
+            WeatherDressWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("How to Dress")
+        .description("Shows clothing suggestion based on the weather.")
+        .supportedFamilies([.systemSmall])
+    }
+}

--- a/WeatherDressApp/WeatherService.swift
+++ b/WeatherDressApp/WeatherService.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+struct Weather: Decodable {
+    let temperature: Double
+    let condition: String
+    let rainProbability: Double
+}
+
+final class WeatherService {
+    func fetchWeather() async throws -> Weather {
+        // Replace with your favorite API. Example uses open-meteo.com which requires no key.
+        let url = URL(string: "https://api.open-meteo.com/v1/forecast?latitude=52.52&longitude=13.41&current_weather=true")!
+        let (data, _) = try await URLSession.shared.data(from: url)
+        let decoded = try JSONDecoder().decode(OpenMeteoResponse.self, from: data)
+        return Weather(temperature: decoded.currentWeather.temperature, condition: decoded.currentWeather.weathercodeDescription, rainProbability: decoded.currentWeather.precipitationProbability)
+    }
+}
+
+private struct OpenMeteoResponse: Decodable {
+    let currentWeather: CurrentWeather
+
+    enum CodingKeys: String, CodingKey {
+        case currentWeather = "current_weather"
+    }
+}
+
+private struct CurrentWeather: Decodable {
+    let temperature: Double
+    let weathercode: Int
+    let precipitationProbability: Double
+
+    enum CodingKeys: String, CodingKey {
+        case temperature
+        case weathercode
+        case precipitationProbability = "precipitation_probability"
+    }
+
+    var weathercodeDescription: String {
+        switch weathercode {
+        case 0: return "Clear"
+        case 1,2,3: return "Partly Cloudy"
+        case 45,48: return "Fog"
+        case 51,53,55: return "Drizzle"
+        case 61,63,65: return "Rain"
+        case 71,73,75: return "Snow"
+        default: return "" 
+        }
+    }
+}

--- a/WeatherDressApp/WeatherViewModel.swift
+++ b/WeatherDressApp/WeatherViewModel.swift
@@ -1,0 +1,31 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class WeatherViewModel: ObservableObject {
+    @Published var weather: Weather?
+    private let service = WeatherService()
+
+    func load() async {
+        do {
+            weather = try await service.fetchWeather()
+        } catch {
+            print("Failed to fetch weather: \(error)")
+        }
+    }
+
+    func advice(for weather: Weather) -> String {
+        var result = ""
+        if weather.temperature < 10 {
+            result = "Wear a coat."
+        } else if weather.temperature < 20 {
+            result = "Wear a jacket."
+        } else {
+            result = "Short sleeves are fine."
+        }
+        if weather.rainProbability > 0.5 {
+            result += " Bring an umbrella."
+        }
+        return result
+    }
+}


### PR DESCRIPTION
## Summary
- add a README for the WeatherDress app
- implement a SwiftUI view model, service and main app
- add a WidgetKit extension for clothing advice

## Testing
- `swift --version`
- `swiftc WeatherDressApp/WeatherDressApp.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6844536c641c83268b0900381c4cf569